### PR TITLE
Forced refresh after event is deleted and fixing error messages

### DIFF
--- a/client/src/components/DeleteUserEvent/DeleteEventForm.jsx
+++ b/client/src/components/DeleteUserEvent/DeleteEventForm.jsx
@@ -32,11 +32,11 @@ function DeleteEventForm(event) {
             })
             .catch((err) => setDeleteEventError(err.message));
     };
-
+    if (DeleteEventError.includes("Event could not be found")) return <Redirect to="/" />;
     return (
         <div>
             {DeleteEventError ? (
-                <Alert variant="danger">{DeleteEventError}</Alert>
+                <Alert variant="danger">{DeleteEventError.replace("GraphQL error: ", "")}</Alert>
             ) : undefined}
             <Form onSubmit={handleSubmit}>
                 <Form.Group controlId="nameGroup">

--- a/client/src/components/Login/LoginForm.jsx
+++ b/client/src/components/Login/LoginForm.jsx
@@ -47,7 +47,7 @@ function LoginForm() {
     login(loginInput)
       .then((resp) => {
         dispatch({ type: "SET_LOGIN_STATUS", payload: true });
-        dispatch({ type: "SET_CURRENT_USER", payload: resp.data.login.id});
+        dispatch({ type: "SET_CURRENT_USER", payload: resp.data.login.id });
         setLoginVariables({
           isLoggedIn: true,
           isConfirmed: resp.data.login.confirmed,
@@ -63,7 +63,7 @@ function LoginForm() {
 
   return (
     <div>
-      {loginError ? <Alert variant="danger">{loginError}</Alert> : undefined}
+      {loginError ? <Alert variant="danger">{loginError.replace("GraphQL error: ", "")}</Alert> : undefined}
       <Form onSubmit={handleSubmit}>
         <Form.Group controlId="nameGroup">
           <Form.Label>Email</Form.Label>

--- a/client/src/components/Profile/ProfileForm.jsx
+++ b/client/src/components/Profile/ProfileForm.jsx
@@ -55,7 +55,7 @@ function ProfileForm() {
   return (
     <div>
       {profileError ? (
-        <Alert variant="danger">{profileError}</Alert>
+        <Alert variant="danger">{"Please fill out all of the information"}</Alert>
       ) : undefined}
       <Form onSubmit={handleSubmit}>
         <Form.Group controlId="yearGroup">

--- a/client/src/components/Registration/Registration.jsx
+++ b/client/src/components/Registration/Registration.jsx
@@ -31,7 +31,6 @@ function Registration(event) {
             .catch((err) => setRegisterError(err.message));
     };
 
-    // if (hasRegistered) return <Redirect to="/" />;
     return (
         <div>
             {registerError ? (

--- a/client/src/components/ResetPassword/ResetRequestForm.jsx
+++ b/client/src/components/ResetPassword/ResetRequestForm.jsx
@@ -47,7 +47,7 @@ function ResetRequestForm() {
   return (
     <div>
       {resetRequestError ? (
-        <Alert variant="danger">{resetRequestError}</Alert>
+        <Alert variant="danger">{resetRequestError.replace("GraphQL error: ", "")}</Alert>
       ) : undefined}
       <Form onSubmit={handleSubmit}>
         <Form.Group controlId="nameGroup">

--- a/client/src/components/Signup/SignupForm.jsx
+++ b/client/src/components/Signup/SignupForm.jsx
@@ -59,7 +59,7 @@ function SignupForm() {
 
   return (
     <div>
-      {signUpError ? <Alert variant="danger">{signUpError}</Alert> : undefined}
+      {signUpError ? <Alert variant="danger">{"Please fill out all of the information"}</Alert> : undefined}
       <Form onSubmit={handleSubmit}>
         <Form.Group controlId="nameGroup">
           <Form.Label>Full name</Form.Label>


### PR DESCRIPTION
Forced refresh after event is deleted in DeleteEventForm and fixed the error messages to remove the GraphQL error tag at the beginning of the error messages.  